### PR TITLE
Print error message when meta.json is corrupt

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -765,8 +765,8 @@ function update(cb) {
             if (err.constructor.name === 'SyntaxError') {
                 return cb('Corrupt meta.json file');
             }
-            // no meta file; nothing to do
-            return cb(null);
+            // unknown err, possibly no meta file; nothing to do
+            return cb(err.message);
         }
 
         var remotes = Object.keys(clientMetaFile.toJSON().remotes);

--- a/bin/idl.js
+++ b/bin/idl.js
@@ -762,6 +762,9 @@ function update(cb) {
 
     function onMeta(err, meta) {
         if (err) {
+            if (err.constructor.name === 'SyntaxError') {
+                return cb('Corrupt meta.json file');
+            }
             // no meta file; nothing to do
             return cb(null);
         }


### PR DESCRIPTION
This pull request adds support for printing an error when meta.json is corrupted and unreadable.

cc: @raynos @kriskowal @prashantv @blampe @abhinav @breerly 