### PR TITLE
Bump read-json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "pty.js": "^0.3.0",
     "rc": "^1.1.1",
     "read-dir-files": "0.1.1",
-    "read-json": "0.1.0",
+    "read-json": "1.0.3",
     "rimraf": "^2.3.4",
     "run-parallel": "1.1.1",
     "run-series": "1.1.1",


### PR DESCRIPTION
This is due to https://medium.com/@azerbike/i-ve-just-liberated-my-modules-9045c06be67c. `read-json` was one of the casualties. Just needs a version bump.