### PR TITLE
Switch to @uber/eslint-config

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+coverage/

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,19 @@
 {
-    "rules": {
-        "max-statements": [2, 25]
-    }
+  "extends": [
+    "@uber/eslint-config"
+  ],
+
+  "rules": {
+    "block-scoped-var": 0,
+    "callback-return": 0,
+    "consistent-return": 0,
+    "indent": ["error", 4, { "SwitchCase": 1 }],
+    "max-statements": [2, 25],
+    "no-else-return": 0,
+    "no-implicit-coercion": 0,
+    "no-inline-comments": 0,
+    "no-invalid-this": 0,
+    "no-shadow": 0,
+    "no-unneeded-ternary": 0
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,19 +1,22 @@
 {
-  "extends": [
-    "@uber/eslint-config"
-  ],
+  "extends": "perf-standard",
 
   "rules": {
     "block-scoped-var": 0,
     "callback-return": 0,
     "consistent-return": 0,
-    "indent": ["error", 4, { "SwitchCase": 1 }],
+    "indent": [2, 4, { "SwitchCase": 1 }],
     "max-statements": [2, 25],
     "no-else-return": 0,
     "no-implicit-coercion": 0,
     "no-inline-comments": 0,
     "no-invalid-this": 0,
     "no-shadow": 0,
-    "no-unneeded-ternary": 0
+    "no-unneeded-ternary": 0,
+    "no-useless-concat": 0,
+    "perf-standard/check-function-inline": 0,
+    "perf-standard/no-array-iterators": 0,
+    "perf-standard/no-instanceof-guard": 0,
+    "perf-standard/no-self-in-constructor": 0
   }
 }

--- a/bin/idl-daemon.js
+++ b/bin/idl-daemon.js
@@ -36,7 +36,7 @@ var util = require('util');
 
 var Repository = require('../repository.js');
 
-/*eslint no-process-env: 0*/
+/* eslint no-process-env: 0 */
 var HOME = process.env.HOME;
 
 module.exports = IDLDaemon;
@@ -56,7 +56,7 @@ function main() {
     });
 }
 
-/*eslint no-console: 0, no-process-exit: 0 */
+/* eslint no-console: 0, no-process-exit: 0 */
 function IDLDaemon(opts) {
     if (!(this instanceof IDLDaemon)) {
         return new IDLDaemon(opts);

--- a/bin/idl.js
+++ b/bin/idl.js
@@ -953,7 +953,7 @@ function preauth(shell, command, ignoreList, cb) {
 
     cb = once(cb);
     var args = ['-c', command];
-    var opts = {stdio: 'inherit'};
+    var opts = { stdio: 'inherit' };
     var pa = spawn(shell, args, opts);
     pa.on('error', cb);
     pa.on('exit', cb);

--- a/bin/idl.js
+++ b/bin/idl.js
@@ -80,10 +80,10 @@ var minimistOpts = {
     }
 };
 
-/*eslint no-process-env: 0*/
+/* eslint no-process-env: 0 */
 var HOME = process.env.HOME;
 
-/*eslint no-console: 0, no-process-exit:0 */
+/* eslint no-console: 0, no-process-exit:0 */
 module.exports = IDL;
 
 function main() {
@@ -277,7 +277,7 @@ IDL.exec = function exec(string, options, cb) {
 };
 
 function help(helpUrl, cb) {
-    /*eslint-disable max-len*/
+    /* eslint-disable max-len */
     var helpText = [
         'usage: idl --repository=<repo> [--help] [-h]',
         '                    <command> <args>',
@@ -304,7 +304,7 @@ function help(helpUrl, cb) {
 
     helpText = helpText.join('\n');
 
-    /*eslint-enable max-len*/
+    /* eslint-enable max-len */
     setImmediate(cb.bind(this, null, helpText));
 }
 

--- a/git-process.js
+++ b/git-process.js
@@ -19,7 +19,7 @@
 // THE SOFTWARE.
 
 'use strict';
-/*eslint-disable no-console*/
+/* eslint-disable no-console */
 var assert = require('assert');
 var spawn = require('child_process').spawn;
 var console = require('console');

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "xtend": "4.0.0"
   },
   "devDependencies": {
+    "@uber/eslint-config": "^3.0.1",
+    "eslint": "2.13.1",
     "fixtures-fs": "2.0.0",
     "istanbul": "^0.3.5",
     "opn": "^1.0.1",
@@ -54,8 +56,7 @@
     "tape-cluster": "2.0.0",
     "time-mock": "0.1.2",
     "timekeeper": "0.0.5",
-    "uber-licence": "^1.5.1",
-    "uber-standard": "3.6.4"
+    "uber-licence": "^1.5.1"
   },
   "licenses": [
     {
@@ -67,7 +68,7 @@
     "add-licence": "uber-licence",
     "test": "npm run lint -s && npm run cover -s",
     "unit-test": "node test/index.js",
-    "lint": "standard -v",
+    "lint": "eslint . --config .eslintrc",
     "cover": "istanbul cover --report html --print detail -- test/index.js && npm run check-cover -s",
     "check-cover": "istanbul check-coverage --branches=100 --lines=100 --functions=100 || echo 'coverage failed'",
     "view-cover": "opn ./coverage/index.html",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "xtend": "4.0.0"
   },
   "devDependencies": {
-    "@uber/eslint-config": "^3.0.1",
-    "eslint": "2.13.1",
+    "eslint": "1.8.0",
+    "eslint-config-perf-standard": "2.1.1",
     "fixtures-fs": "2.0.0",
     "istanbul": "^0.3.5",
     "opn": "^1.0.1",

--- a/repository.js
+++ b/repository.js
@@ -51,7 +51,10 @@ function Repository(opts) {
     self.upstream = opts.upstream;
     self.repositoryDirectory = opts.repositoryDirectory;
 
-    self.idlDirectory = path.join(self.repositoryDirectory, self.idlDirectoryName);
+    self.idlDirectory = path.join(
+        self.repositoryDirectory,
+        self.idlDirectoryName
+    );
     self.logger = opts.logger;
 
     self.meta = MetaFile({

--- a/test/idl.js
+++ b/test/idl.js
@@ -172,7 +172,9 @@ TestCluster.test('run `idl version`', {
         if (err) {
             assert.ifError(err);
         }
+        /* eslint-disable global-require */
         var expected = require('../package.json').version;
+        /* eslint-enable global-require */
         assert.equal(stdout, expected);
         assert.end();
     });
@@ -257,7 +259,7 @@ TestCluster.test('run `idl publish`', {
         );
         assert.equal(
             results[3].upstream.files[filepath],
-            template(updatedThriftIdlTemplate, {remoteName: 'A'}),
+            template(updatedThriftIdlTemplate, { remoteName: 'A' }),
             'Correct published thrift file for service A (publish run ' +
                 'on changed thrift file)'
         );
@@ -375,13 +377,13 @@ TestCluster.test('run `idl update`', {
         // Remote A and B updated and published. Update run.
         assert.equal(
             data[8].local.idl['github.com'].org.a['service.thrift'],
-            template(updatedThriftIdlTemplate, {remoteName: 'A'}),
+            template(updatedThriftIdlTemplate, { remoteName: 'A' }),
             'Correct thrift A file locally'
         );
 
         assert.equal(
             data[8].local.idl['github.com'].org.b['service.thrift'],
-            template(updatedThriftIdlTemplate, {remoteName: 'B'}),
+            template(updatedThriftIdlTemplate, { remoteName: 'B' }),
             'Correct thrift B file locally'
         );
 

--- a/test/unit/get-dependencies.js
+++ b/test/unit/get-dependencies.js
@@ -71,8 +71,11 @@ var fixtures = {
 
 test('getServiceDependenciesFromIncludes',
     withFixtures(fixturesPath, fixtures, function t(assert) {
-    getDependencies(
-        path.resolve(__dirname, '../fixtures/idl/github.com/a-team/foo'),
+        getDependencies(
+            path.resolve(__dirname, '../fixtures/idl/github.com/a-team/foo'),
+            onIncludes
+        );
+
         function onIncludes(err, serviceDependencies) {
             if (err) {
                 assert.ifError(err);
@@ -89,5 +92,5 @@ test('getServiceDependenciesFromIncludes',
 
             assert.end();
         }
-    );
-}));
+    })
+);


### PR DESCRIPTION
Switching to @uber/eslint-config over deprecated uber-standard. Fixed some lint issues, but ignored others to keep this diff on the smaller side. Will address some of the ignored rules later.

cc/ @kriskowal @Raynos 