### PR TITLE
All commands should print nice error for corrupt meta.json

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -762,11 +762,7 @@ function update(cb) {
 
     function onMeta(err, meta) {
         if (err) {
-            if (err.constructor.name === 'SyntaxError') {
-                return cb('Corrupt meta.json file');
-            }
-            // unknown err, possibly no meta file; nothing to do
-            return cb(err.message);
+            return cb(err);
         }
 
         var remotes = Object.keys(clientMetaFile.toJSON().remotes);

--- a/meta-file.js
+++ b/meta-file.js
@@ -51,6 +51,9 @@ MetaFile.prototype.readFile = function readFile(cb) {
             self._remotes = {};
             return cb(null);
         } else if (err) {
+            if (err.constructor.name === 'SyntaxError') {
+                err.message = 'Corrupt meta.json file: ' + err.message;
+            }
             return cb(err);
         }
 

--- a/test/idl.js
+++ b/test/idl.js
@@ -425,8 +425,12 @@ TestCluster.test('run `idl update` with corrupt meta.json', {
         if (err) {
             assert.ifError(err);
         }
-        var expected = 'Corrupt meta.json file';
-        assert.equal(data[2].stderr, expected, 'Warn user about corrupt meta');
+        var expected = 'Corrupt meta.json file: Unexpected end of input';
+        assert.equal(
+            data[2].stderr.message,
+            expected,
+            'Warn user about corrupt meta'
+        );
         tk.reset();
         assert.end();
     }


### PR DESCRIPTION
Previously idl only printed a nice error message due to a corrupt meta.json file for `idl update`. This change makes it so we get a nice error message regardless of the command being run.

Closes https://github.com/uber/idl/issues/43

cc/ @Raynos @kriskowal 