### PR TITLE
fix nested folder import issues

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -518,8 +518,8 @@ function fetch(service, cb) {
             return cb(err);
         }
 
-        var alreadyFetched = !!clientMetaFile.toJSON().remotes[service];
-        var existsInRegistry = !!self.meta.toJSON().remotes[service];
+        var alreadyFetched = findService(clientMetaFile.toJSON(), service);
+        var existsInRegistry = findService(self.meta.toJSON(), service);
 
         if (!existsInRegistry) {
             cb(UnknownServiceError({
@@ -532,6 +532,17 @@ function fetch(service, cb) {
         } else {
             self.update(onUpdate);
         }
+    }
+
+    function findService(json, service) {
+        var path = service.split('/');
+        for (var i = path.length; i >= 0; i--) {
+            var fetched = json.remotes[path.slice(0, i).join('/')];
+            if (fetched) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function onUpdate(err) {

--- a/test/idl-daemon.js
+++ b/test/idl-daemon.js
@@ -22,7 +22,7 @@
 
 var TestCluster = require('./lib/test-cluster.js');
 var defineFixture = require('./lib/define-fixture');
-var thriftIdl = require('./lib/thrift-idl');
+var thriftIdl = require('./lib/thrift-idl').thriftIdl;
 
 TestCluster.test('run the idl-daemon', {
 }, function t(cluster, assert) {

--- a/test/lib/define-fixture.js
+++ b/test/lib/define-fixture.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var thriftIdl = require('./thrift-idl');
+var thriftIdl = require('./thrift-idl').thriftIdl;
 
 module.exports = defineFixture;
 

--- a/test/lib/thrift-idl.js
+++ b/test/lib/thrift-idl.js
@@ -22,7 +22,10 @@
 
 var template = require('string-template');
 
-module.exports = thriftIdl;
+module.exports = {
+    thriftIdl: thriftIdl,
+    thriftIdlWithIncludes: thriftIdlWithIncludes
+};
 
 function thriftIdl(serviceName) {
     var idlTemplate = [
@@ -34,4 +37,26 @@ function thriftIdl(serviceName) {
     return template(idlTemplate, {
         serviceName: serviceName
     });
+}
+
+function thriftIdlWithIncludes(serviceName, includes) {
+    var idlTemplate = [
+        '{includes}',
+        'service {serviceName} {',
+        '    i32 echo(1:i32 value)',
+        '}'
+    ].join('\n') + '\n';
+
+    return template(idlTemplate, {
+        serviceName: serviceName,
+        includes: includes.length > 0 ? getIncludesTemplate(includes) : ''
+    });
+}
+
+function getIncludesTemplate(includes) {
+    var includeTemplate = [];
+    for (var i = 0; i < includes.length; i++) {
+        includeTemplate.push('include {' + i + '}')
+    }
+    return template(includeTemplate.join('\n') + '\n', includes);
 }


### PR DESCRIPTION
in case of nested folder import in another service, ensure that we walk up the path to find the actual service.

Currently a service A can import a thrift from another service's nested folder like this. 

```
a.thrift: 

include ../b/nestedFolder/nestedThrift.thrift

service A {
...
}
```

At the time of checking & fetching dependency, ensure that we walk up the nested folder path to find the correct service.