### PR TITLE
Prepare patch release 3.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+# v3.1.7
+
+- Fixes a bug when an IDL depends on another IDL that is not in the root of the
+  dependency's repository path. (@ankits)
+
+# v3.1.6
+
 # v3.1.5
 
 - Bug fix to address issues with EMFILE errors

--- a/bin/idl.js
+++ b/bin/idl.js
@@ -518,8 +518,8 @@ function fetch(service, cb) {
             return cb(err);
         }
 
-        var alreadyFetched = !!clientMetaFile.toJSON().remotes[service];
-        var existsInRegistry = !!self.meta.toJSON().remotes[service];
+        var alreadyFetched = findService(clientMetaFile.toJSON(), service);
+        var existsInRegistry = findService(self.meta.toJSON(), service);
 
         if (!existsInRegistry) {
             cb(UnknownServiceError({
@@ -532,6 +532,17 @@ function fetch(service, cb) {
         } else {
             self.update(onUpdate);
         }
+    }
+
+    function findService(json, service) {
+        var path = service.split('/');
+        for (var i = path.length; i >= 0; i--) {
+            var fetched = json.remotes[path.slice(0, i).join('/')];
+            if (fetched) {
+                return true;
+            }
+        }
+        return false;
     }
 
     function onUpdate(err) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idl",
-  "version": "3.1.6",
+  "version": "3.1.7",
   "description": "A CLI for managing thrift IDL files",
   "keywords": [],
   "contributors": [

--- a/test/idl-daemon.js
+++ b/test/idl-daemon.js
@@ -22,7 +22,7 @@
 
 var TestCluster = require('./lib/test-cluster.js');
 var defineFixture = require('./lib/define-fixture');
-var thriftIdl = require('./lib/thrift-idl');
+var thriftIdl = require('./lib/thrift-idl').thriftIdl;
 
 TestCluster.test('run the idl-daemon', {
 }, function t(cluster, assert) {

--- a/test/idl.js
+++ b/test/idl.js
@@ -397,7 +397,6 @@ TestCluster.test('run `idl publish nested folders`', {
 }, function t(cluster, assert) {
 
     var now = Date.now();
-    debugger;
     series([
         publishRemote(cluster, 'S', now + 1000, false),
         publishRemote(cluster, 'S', now + 2000, false),
@@ -408,7 +407,6 @@ TestCluster.test('run `idl publish nested folders`', {
     ], onResults);
 
     function onResults(err, results) {
-        debugger;
         if (err) {
             assert.ifError(err);
         }
@@ -555,7 +553,6 @@ TestCluster.test('run `idl publish nested folders`', {
 }, function t(cluster, assert) {
 
     var now = Date.now();
-    debugger;
     series([
         publishRemote(cluster, 'S', now + 1000, false),
         updateRemote(cluster, 'S', now + 2000, false, true),
@@ -566,7 +563,6 @@ TestCluster.test('run `idl publish nested folders`', {
     ], onResults);
 
     function onResults(err, results) {
-        debugger;
         if (err) {
             assert.ifError(err);
         }

--- a/test/lib/define-fixture.js
+++ b/test/lib/define-fixture.js
@@ -20,7 +20,7 @@
 
 'use strict';
 
-var thriftIdl = require('./thrift-idl');
+var thriftIdl = require('./thrift-idl').thriftIdl;
 
 module.exports = defineFixture;
 

--- a/test/lib/thrift-idl.js
+++ b/test/lib/thrift-idl.js
@@ -22,7 +22,10 @@
 
 var template = require('string-template');
 
-module.exports = thriftIdl;
+module.exports = {
+    thriftIdl: thriftIdl,
+    thriftIdlWithIncludes: thriftIdlWithIncludes
+};
 
 function thriftIdl(serviceName) {
     var idlTemplate = [
@@ -34,4 +37,26 @@ function thriftIdl(serviceName) {
     return template(idlTemplate, {
         serviceName: serviceName
     });
+}
+
+function thriftIdlWithIncludes(serviceName, includes) {
+    var idlTemplate = [
+        '{includes}',
+        'service {serviceName} {',
+        '    i32 echo(1:i32 value)',
+        '}'
+    ].join('\n') + '\n';
+
+    return template(idlTemplate, {
+        serviceName: serviceName,
+        includes: includes.length > 0 ? getIncludesTemplate(includes) : ''
+    });
+}
+
+function getIncludesTemplate(includes) {
+    var includeTemplate = [];
+    for (var i = 0; i < includes.length; i++) {
+        includeTemplate.push('include {' + i + '}')
+    }
+    return template(includeTemplate.join('\n') + '\n', includes);
 }


### PR DESCRIPTION
This release addresses a problem when a dependency IDL is in a subdirectory of
its project location.

IDL makes the simplifying assumption that all project IDL files are in one
directory. This assumption is critical to avoid overlapping ownership hazards.
This release relaxes the assumption and handles this existing case.
A future minor release will protect against the hazard where a common ancestory
can overwrite all the IDL for nested repository locations.