### PR TITLE
Prevent fetch calls on IDL files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 
 # (unreleased)
 
-- No changes yet.
-
+- Prevent users from using `fetch` on an IDL file, instead of a service name.
+  This fixes a silent failure that would prevent updates after reading the IDL
+  entry in `meta.json`.
 
 # v3.1.12 (2018-01-25)
 


### PR DESCRIPTION
This change prevents users from calling `idl fetch` on a thrift
file. Users should be calling `fetch` with a service name instead.

A reported issue discovered that `update` wasn't fetching the latest
IDL for a service. Investigation showed that `meta.json` had incorrect
entries: some `remotes` specified a `.thrift` extension. This
indicates users calling `idl fetch` on a specifc IDL file. Reading the
`meta.json` file on later calls to `fetch` and `update` caused IDL to
silently fail with a 0 exit code.

Users would see IDL updates up to the first invalid entry and then IDL
would quit.

This change will update entries with `.thrift` extensions for
backwards compatibility.