### PR TITLE
Fix various lint errors

### DIFF
--- a/bin/idl.js
+++ b/bin/idl.js
@@ -31,7 +31,6 @@ var mkdirp = require('mkdirp');
 var DebugLogtron = require('debug-logtron');
 var extend = require('xtend');
 var textTable = require('text-table');
-var parallel = require('run-parallel');
 var cpr = require('cpr');
 var rc = require('rc');
 var rcUtils = require('rc/lib/utils');
@@ -484,7 +483,7 @@ function fetch(service, cb) {
     self.update(onUpdate);
 
     function onUpdate(err) {
-        if (err != null) {
+        if (!err) {
             return cb(err);
         }
 
@@ -524,7 +523,6 @@ function fetchOneService(service, cb) {
             return cb(err);
         }
 
-        var alreadyFetched = findService(localMeta.toJSON(), service);
         var existsInRegistry = findService(self.meta.toJSON(), service);
 
         if (!existsInRegistry) {
@@ -1019,7 +1017,8 @@ function toString() {
 }
 
 // If configured in .idlrc, runs a command that ensures that subsequent git
-// commands interacting with the git registry's repository run without interactive authentication prompts.
+// commands interacting with the git registry's repository run without
+// interactive authentication prompts.
 // This is important since these command typically run in a pty to obscure hide
 // their output and detect any interactive authentication prompts (via PAM)
 // that might open /dev/tty to avoid mucking with stdio.

--- a/git-commands.js
+++ b/git-commands.js
@@ -36,7 +36,7 @@ function addCommitTagAndPushToOrigin(opts, callback) {
     var ctx = {
         cwd: opts.cwd,
         logger: opts.logger,
-        debugGit: opts.debugGit,
+        debugGit: opts.debugGit
     };
 
     series([

--- a/test/unit/get-dependencies.js
+++ b/test/unit/get-dependencies.js
@@ -98,7 +98,7 @@ test('getServiceDependenciesFromIncludes',
                 'github.com/a-team/bar',
                 'github.com/b-team/baz',
                 'github.com/b-team/qux',
-                'github.com/company/common',
+                'github.com/company/common'
             ];
 
             assert.deepEqual(serviceDependencies, expected);


### PR DESCRIPTION
This fixes various lint errors that prevent running tests locally. Failing lint still let the builds pass which means that test are not actually passing on latest master/dev 👎

This means that this PR won't pass builds since **tests are actually running now**.

This will require a separate change to get tests passing. However, a more robust solution may arise from @kriskowal later, which could make fixing these tests a non-issue.